### PR TITLE
Improve ApplyPrestashopDbUpgrade command and Upgrader robustness

### DIFF
--- a/src/Command/ApplyPrestashopDbUpgrade.php
+++ b/src/Command/ApplyPrestashopDbUpgrade.php
@@ -37,14 +37,15 @@ class ApplyPrestashopDbUpgrade extends Command
         $this
             ->setName('hhennes:psmigration:upgrade-db')
             ->setDescription('Apply db upgrade from current version to last version')
-            ->addArgument('from-version', InputArgument::REQUIRED, 'Version from where the db upgrade should start')
-            ->addArgument('to-version', InputArgument::REQUIRED, 'Last where the db upgrade should stop')
+            ->addArgument('from-version', InputArgument::OPTIONAL, 'Version from where the db upgrade should start (defaults to current DB version)')
+            ->addArgument('to-version', InputArgument::OPTIONAL, 'Last version where the db upgrade should stop')
             ->addOption('get-version', null, InputOption::VALUE_NONE, 'Get the current db Version')
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Get only the list of db upgrades to apply')
             ->addOption('no-db-config-update', null, InputOption::VALUE_NONE, 'Do not update the PS_VERSION_DB configuration')
             ->setHelp(
                 'This command allow to run db upgrade of the module autoupgrade without running it directly' . PHP_EOL
                 . 'Thus it allows to push the code through CI/CD or to run this command to finish the upgrade after the push' . PHP_EOL
+                . 'If from-version is omitted, the current DB version (PS_VERSION_DB) is used automatically' . PHP_EOL
                 . 'You can also get only the current db version with option --get-version' . PHP_EOL
                 . 'And the list of upgrades which will be applied with the option --dry-run'
             );
@@ -58,25 +59,32 @@ class ApplyPrestashopDbUpgrade extends Command
         if ($input->getOption('get-version')) {
             $output->writeln(sprintf('<info>Current Db installed version : %s</info>', $this->getCurrentVersion()));
 
-            return 0;
+            return Command::SUCCESS;
         }
+
+        $fromVersion = $input->getArgument('from-version') ?? $this->getCurrentVersion();
+        $toVersion = $input->getArgument('to-version');
+
+        if (!$toVersion) {
+            $output->writeln('<error>Argument to-version is required</error>');
+
+            return Command::FAILURE;
+        }
+
         if (!\Module::getInstanceByName('autoupgrade') || !\Module::isInstalled('autoupgrade')) {
             $output->writeln(
                 '<error>The module autoupgrade is required and should be installed to use this tool</error>'
             );
 
-            return 1;
+            return Command::FAILURE;
         }
-
-        $fromVersion = $input->getArgument('from-version');
-        $toVersion = $input->getArgument('to-version');
-        $dryRun = $input->getOption('dry-run');
 
         if (!$this->isvalidPsVersion($fromVersion) || !$this->isvalidPsVersion($toVersion)) {
             $output->writeln('<error>Please enter valid from and to versions</error>');
 
-            return 1;
+            return Command::FAILURE;
         }
+
         $output->writeln('<info>Upgrade process start</info>');
         try {
             $logger = new ConsoleLogger($output);
@@ -84,7 +92,7 @@ class ApplyPrestashopDbUpgrade extends Command
             $dbUpgrader
                 ->setOldVersion($fromVersion)
                 ->setDestinationVersion($toVersion);
-            if (false !== $dryRun) {
+            if ($input->getOption('dry-run')) {
                 $output->writeln('<comment>==== Dry run mode, nothing will be applied ===</comment>');
                 $dbUpgrader->setRunMode(Upgrader::RUN_MODE_DRY_RUN);
             }
@@ -97,10 +105,10 @@ class ApplyPrestashopDbUpgrade extends Command
             $output->writeln('<error>Unable to apply upgrade, please check logs</error>');
             $logger->error('Error : ' . $e->getMessage());
 
-            return 1;
+            return Command::FAILURE;
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     /**

--- a/src/DbUpgrader/Upgrader.php
+++ b/src/DbUpgrader/Upgrader.php
@@ -109,6 +109,9 @@ class Upgrader
      */
     public function setRunMode(string $runMode): self
     {
+        if (!in_array($runMode, [self::RUN_MODE_STANDARD, self::RUN_MODE_DRY_RUN])) {
+            throw new \InvalidArgumentException(sprintf('Invalid run mode "%s"', $runMode));
+        }
         $this->runMode = $runMode;
 
         return $this;
@@ -233,7 +236,7 @@ class Upgrader
      *
      * @return void
      */
-    protected function runPhpQuery(string $upgrade_file, string $query)
+    protected function runPhpQuery(string $upgrade_file, string $query): void
     {
         // Parsing php code
         $pos = strpos($query, '/* PHP:') + strlen('/* PHP:');
@@ -283,12 +286,13 @@ class Upgrader
         }
 
         if (isset($phpRes) && (is_array($phpRes) && !empty($phpRes['error'])) || $phpRes === false) {
-            $this->logger->error('
-                [ERROR] PHP ' . $upgrade_file . ' ' . $query . "\n" . '
-                ' . (empty($phpRes['error']) ? '' : $phpRes['error'] . "\n") . '
-                ' . (empty($phpRes['msg']) ? '' : ' - ' . $phpRes['msg'] . "\n"));
+            $this->logger->error(
+                '[ERROR] PHP ' . $upgrade_file . ' ' . $query . "\n"
+                . (empty($phpRes['error']) ? '' : $phpRes['error'] . "\n")
+                . (empty($phpRes['msg']) ? '' : ' - ' . $phpRes['msg'] . "\n")
+            );
         } else {
-            $this->logger->debug('<div class="upgradeDbOk">[OK] PHP ' . $upgrade_file . ' : ' . $query . '</div>');
+            $this->logger->debug('[OK] PHP ' . $upgrade_file . ' : ' . $query);
         }
     }
 
@@ -315,12 +319,12 @@ class Upgrader
     /**
      * Run Sql Query (Fonction from module Autoupgrade)
      *
-     * @param $upgrade_file
-     * @param $query
+     * @param string $upgrade_file
+     * @param string $query
      *
      * @return void
      */
-    protected function runSqlQuery($upgrade_file, $query)
+    protected function runSqlQuery(string $upgrade_file, string $query): void
     {
         if (strstr($query, 'CREATE TABLE') !== false) {
             $pattern = '/CREATE TABLE.*[`]*' . _DB_PREFIX_ . '([^`]*)[`]*\s\(/';
@@ -334,17 +338,14 @@ class Upgrader
         }
 
         if ($this->db->execute($query, false)) {
-            $this->logger->debug('<div class="upgradeDbOk">[OK] SQL ' . $upgrade_file . ' ' . $query . '</div>');
+            $this->logger->debug('[OK] SQL ' . $upgrade_file . ' ' . $query);
 
             return;
         }
 
         $error = $this->db->getMsgError();
         $error_number = $this->db->getNumberError();
-        $this->logger->warning('
-            <div class="upgradeDbError">
-            [WARNING] SQL ' . $upgrade_file . '
-            ' . $error_number . ' in ' . $query . ': ' . $error . '</div>');
+        $this->logger->warning('[WARNING] SQL ' . $upgrade_file . ' ' . $error_number . ' in ' . $query . ': ' . $error);
 
         $duplicates = ['1050', '1054', '1060', '1061', '1062', '1091'];
         if (!in_array($error_number, $duplicates)) {

--- a/tests/php/unit/Command/ApplyPrestashopDbUpgradeTest.php
+++ b/tests/php/unit/Command/ApplyPrestashopDbUpgradeTest.php
@@ -20,6 +20,7 @@ namespace Hhennes\PsMigrationUpgradeDb\Tests\Unit\Command;
 use Hhennes\PsMigrationUpgradeDb\Command\ApplyPrestashopDbUpgrade;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class ApplyPrestashopDbUpgradeTest extends TestCase
@@ -113,18 +114,15 @@ class ApplyPrestashopDbUpgradeTest extends TestCase
         $this->assertStringContainsString('Apply db upgrade', $this->command->getDescription());
     }
 
-    public function testCommandHasRequiredArguments()
+    public function testCommandHasOptionalArguments()
     {
         $definition = $this->command->getDefinition();
 
         $this->assertTrue($definition->hasArgument('from-version'));
         $this->assertTrue($definition->hasArgument('to-version'));
 
-        $fromVersionArg = $definition->getArgument('from-version');
-        $toVersionArg = $definition->getArgument('to-version');
-
-        $this->assertTrue($fromVersionArg->isRequired());
-        $this->assertTrue($toVersionArg->isRequired());
+        $this->assertFalse($definition->getArgument('from-version')->isRequired());
+        $this->assertFalse($definition->getArgument('to-version')->isRequired());
     }
 
     public function testCommandHasExpectedOptions()
@@ -136,18 +134,35 @@ class ApplyPrestashopDbUpgradeTest extends TestCase
         $this->assertTrue($definition->hasOption('no-db-config-update'));
     }
 
-    public function testGetVersionOption()
+    public function testGetVersionOptionWithoutArguments()
     {
-        $this->commandTester->execute([
-            'from-version' => '1.7.7.0',
-            'to-version' => '1.7.8.0',
-            '--get-version' => true,
-        ]);
+        $this->commandTester->execute(['--get-version' => true]);
 
         $output = $this->commandTester->getDisplay();
         $this->assertStringContainsString('Current Db installed version', $output);
         $this->assertStringContainsString('1.7.8.0', $output);
-        $this->assertEquals(0, $this->commandTester->getStatusCode());
+        $this->assertEquals(Command::SUCCESS, $this->commandTester->getStatusCode());
+    }
+
+    public function testMissingToVersionReturnsError()
+    {
+        $this->commandTester->execute([]);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('to-version is required', $output);
+        $this->assertEquals(Command::FAILURE, $this->commandTester->getStatusCode());
+    }
+
+    public function testFromVersionDefaultsToCurrentVersion()
+    {
+        $this->commandTester->execute([
+            'to-version' => '1.7.8.1',
+        ]);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('Upgrade process start', $output);
+        $this->assertStringContainsString('applied with success', $output);
+        $this->assertEquals(Command::SUCCESS, $this->commandTester->getStatusCode());
     }
 
     public function testInvalidFromVersionReturnsError()
@@ -159,7 +174,7 @@ class ApplyPrestashopDbUpgradeTest extends TestCase
 
         $output = $this->commandTester->getDisplay();
         $this->assertStringContainsString('Please enter valid from and to versions', $output);
-        $this->assertEquals(1, $this->commandTester->getStatusCode());
+        $this->assertEquals(Command::FAILURE, $this->commandTester->getStatusCode());
     }
 
     public function testInvalidToVersionReturnsError()
@@ -171,7 +186,7 @@ class ApplyPrestashopDbUpgradeTest extends TestCase
 
         $output = $this->commandTester->getDisplay();
         $this->assertStringContainsString('Please enter valid from and to versions', $output);
-        $this->assertEquals(1, $this->commandTester->getStatusCode());
+        $this->assertEquals(Command::FAILURE, $this->commandTester->getStatusCode());
     }
 
     public function testValidVersionsWithDryRun()
@@ -185,7 +200,7 @@ class ApplyPrestashopDbUpgradeTest extends TestCase
         $output = $this->commandTester->getDisplay();
         $this->assertStringContainsString('Upgrade process start', $output);
         $this->assertStringContainsString('Dry run mode', $output);
-        $this->assertEquals(0, $this->commandTester->getStatusCode());
+        $this->assertEquals(Command::SUCCESS, $this->commandTester->getStatusCode());
     }
 
     public function testValidVersionsWithUpgrade()
@@ -198,7 +213,7 @@ class ApplyPrestashopDbUpgradeTest extends TestCase
         $output = $this->commandTester->getDisplay();
         $this->assertStringContainsString('Upgrade process start', $output);
         $this->assertStringContainsString('applied with success', $output);
-        $this->assertEquals(0, $this->commandTester->getStatusCode());
+        $this->assertEquals(Command::SUCCESS, $this->commandTester->getStatusCode());
     }
 
     public function testNoDbConfigUpdateOption()
@@ -211,7 +226,7 @@ class ApplyPrestashopDbUpgradeTest extends TestCase
 
         $output = $this->commandTester->getDisplay();
         $this->assertStringContainsString('applied with success', $output);
-        $this->assertEquals(0, $this->commandTester->getStatusCode());
+        $this->assertEquals(Command::SUCCESS, $this->commandTester->getStatusCode());
     }
 
     public function testValidPs17Versions()
@@ -221,7 +236,7 @@ class ApplyPrestashopDbUpgradeTest extends TestCase
             'to-version' => '1.7.8.9',
         ]);
 
-        $this->assertEquals(0, $this->commandTester->getStatusCode());
+        $this->assertEquals(Command::SUCCESS, $this->commandTester->getStatusCode());
     }
 
     public function testValidPs80Versions()
@@ -231,6 +246,6 @@ class ApplyPrestashopDbUpgradeTest extends TestCase
             'to-version' => '8.1.5',
         ]);
 
-        $this->assertEquals(0, $this->commandTester->getStatusCode());
+        $this->assertEquals(Command::SUCCESS, $this->commandTester->getStatusCode());
     }
 }

--- a/tests/php/unit/DbUpgrader/UpgraderTest.php
+++ b/tests/php/unit/DbUpgrader/UpgraderTest.php
@@ -170,6 +170,12 @@ class UpgraderTest extends TestCase
         $this->assertEquals('dry-run', Upgrader::RUN_MODE_DRY_RUN);
     }
 
+    public function testSetRunModeThrowsExceptionForInvalidMode()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->upgrader->setRunMode('invalid-mode');
+    }
+
     public function testGetUpgradeSqlFilesListThrowsExceptionWhenDirectoryNotExists()
     {
         $this->expectException(\PrestaShop\Module\AutoUpgrade\UpgradeException::class);


### PR DESCRIPTION
Fixes #20

## Summary

- **`from-version` is now optional**: when omitted, the command automatically reads the current version from `PS_VERSION_DB`. `--get-version` now works without providing any argument.
- **Symfony return constants**: all `return 0/1` replaced with `Command::SUCCESS` / `Command::FAILURE`.
- **Fixed dry-run condition**: `if (false !== $dryRun)` replaced with `if ($input->getOption('dry-run'))`.
- **`setRunMode()` validation**: throws `\InvalidArgumentException` for unknown values.
- **Type hints**: added `string` and `void` on `runSqlQuery` and `runPhpQuery`.
- **Log messages cleanup**: removed HTML markup (`<div class="upgradeDbOk">`) carried over from the autoupgrade web UI.

## Test plan

- [ ] `--get-version` works without providing `from-version` or `to-version`
- [ ] Omitting `from-version` uses current `PS_VERSION_DB` value automatically
- [ ] Missing `to-version` returns an error with `Command::FAILURE`
- [ ] Invalid `runMode` throws `\InvalidArgumentException`
- [ ] All existing upgrade scenarios (dry-run, standard, no-db-config-update) still pass
- [ ] PHPUnit test suite passes